### PR TITLE
Release 1.0.0 beta.1

### DIFF
--- a/.narval.yml
+++ b/.narval.yml
@@ -315,6 +315,7 @@ suites:
           - test/functional/specs/ability-string.specs.js
           - test/functional/specs/ability-string-enum.specs.js
           - test/functional/specs/ability-number.specs.js
+          - test/functional/specs/ability-number-decimal.specs.js
           - test/functional/specs/ability-number-enum.specs.js
           - test/functional/specs/ability-no-data.specs.js
       coverage: *disable-coverage

--- a/.narval.yml
+++ b/.narval.yml
@@ -86,6 +86,14 @@ schemas:
             fixture: console
             domapic_path: .test
             db_uri: mongodb://localhost:27017/domapic
+      controller-auth-disabled: &e2e-controller-service-auth-disabled
+        name: controller
+        docker:
+          <<: *e2e-controller-service-docker
+          command: test/end-to-end/commands/start-controller-auth-disabled.sh
+        local:
+          <<: *e2e-controller-service-local
+          command: test/end-to-end/commands/start-controller-auth-disabled.sh
       service: &e2e-service-service
         name: service
         docker: &e2e-service-service-docker
@@ -112,6 +120,14 @@ schemas:
             service_name: console
             fixture: console
             domapic_path: .test
+      service-auth-disabled: &e2e-service-service-auth-disabled
+        name: service
+        docker:
+          <<: *e2e-service-service-docker
+          command: test/end-to-end/commands/start-service-auth-disabled.sh
+        local:
+          <<: *e2e-service-service-local
+          command: test/end-to-end/commands/start-service-auth-disabled.sh
       test: &e2e-test
         local: &e2e-test-local
           wait-on:
@@ -478,6 +494,37 @@ suites:
           - test/functional/plugin-specs/config-api.specs.js
       coverage: *disable-coverage
   end-to-end:
+    - name: service-connection-authentication-disabled
+      describe: Service should connect to controller when started first time if authentication is disabled in controller
+      before: *e2e-clean
+      services:
+        - *e2e-mongodb-service
+        - *e2e-controller-service-auth-disabled
+        - *e2e-service-service-auth-disabled
+      test:
+        <<: *e2e-test
+        specs:
+          - test/end-to-end/specs/service-connection.specs.js
+          - test/end-to-end/specs/console-registered.specs.js
+          - test/end-to-end/specs/console-plugin-config-registered.specs.js
+          - test/end-to-end/specs/controller-action-handler.specs.js
+          - test/end-to-end/specs/controller-state-handler.specs.js
+      coverage: *disable-coverage
+    - name: service-reconnection-after-auth-disabled
+      describe: Service should connect to controller when started after connecting with auth disabled
+      services:
+        - *e2e-mongodb-service
+        - *e2e-controller-service
+        - *e2e-service-service
+      test:
+        <<: *e2e-test
+        specs:
+          - test/end-to-end/specs/service-connection.specs.js
+          - test/end-to-end/specs/console-registered.specs.js
+          - test/end-to-end/specs/console-plugin-config-registered.specs.js
+          - test/end-to-end/specs/controller-action-handler.specs.js
+          - test/end-to-end/specs/controller-state-handler.specs.js
+      coverage: *disable-coverage
     - name: service-connection
       describe: Service should connect to controller when started first time if connection options are provided
       before: *e2e-clean

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Removed
 
+## [1.0.0-beta.1] - 2019-01-06
+### BREAKING CHANGES
+- From now, connection process not compatible with Domapic Controller versions lower than 1.0.0-alpha.14.
+
+### Changed
+- Send service name and ability service on connection process. Now connection works even when authentication is disabled.
+- Upgrade domapic-controller version in end-to-end tests.
+- Upgrade domapic-base version.
+
 ## [1.0.0-alpha.5] - 2018-12-17
 ### Added
 - Add servicePluginConfigs client

--- a/README.md
+++ b/README.md
@@ -425,6 +425,8 @@ npm start -- --controller=http://192.168.1.100:3000 --controller-api-key=foo-con
 
 In this way, the module will connect automatically with controller when started.
 
+> If Controller has the authentication disabled, the controller-api-key option will not be necessary to perform the connection.
+
 ### Connect using controller web ui
 
 The connection can be executed using the provided api as well, through the controller web ui. When the module or plugin is started, an api key for connecting is displayed in logs:
@@ -450,6 +452,7 @@ npm start -- --help
 * `controller` - Url of the Domapic Controller to connect with.
 * `controllerApiKey` - Api key that allows connection with controller.
 * `authDisabled` - Array of IPs or CIDR IP ranges with authentication disabled (separated with whitespace). Default is ['127.0.0.1', '::1/128'], so authentication will be disabled for localhost by default. To enable authentication even for localhost, specify `--authDisabled` without any ip.
+* `auth` - If false, authentication will be disabled for all origins. Default is true.
 * `color` - Use ANSI colors in traces.
 * `logLevel` - Tracing level. Choices are 'log', 'trace', 'debug', 'info', 'warn' and 'error'. Default is `info`.
 * `path` - Path to be used as home path for the process, instead of user´s default (a `.domapic` folder will be created inside).
@@ -545,9 +548,9 @@ The Domapic Modules are intended to be used only in your local network by the Do
 * __Enable ssl:__
 	Enable ssl for your module generating an SSL certificate. Use options `--sslCert` and `--sslKey` to define the paths to each file, and remember to use the `--save` option to store that settings for next server restarts. From now, your server will start using *https* instead of *http*.
 
-* __Disable the authentication whitelist:__
-	Authentication can be disabled for desired IPs or IP ranges using the `--authDisabled` option. By default, authentication is disabled only for the 172.0.0.1 IP, in order to make easier the first configuration, but you can disable it for all your local network, etc. Because of security reasons, this is not recommended. Use always the built-in api keys method to identify your Domapic Services.
-	If you want to force the authentication requirement even for localhost, use the `--authDisabled` as a flag, without specifying any IP.
+* __Disabling authentication:__
+  Authentication can be disabled for desired IPs or IP ranges using the `--authDisabled` option, or for all origins using the `--auth=false` option. By default, authentication is disabled only for the 172.0.0.1 IP in order to make easier the first configuration, but you can disable it for your whole your local network, etc. *Because of security reasons, this is not recommended*, take into account that users accessing to services with authentication disabled will have equivalent permissions to an user with "admin" role.
+  If you want to force the authentication requirement even for localhost, use the `--authDisabled` as a flag, without specifying any IP.
 
 ## Logs
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -88,6 +88,7 @@ const Client = function (service, controllerData, serviceData, serviceAbilities,
     return service.tracer.debug(templates.compiled.registeringService())
       .then(() => {
         return apiClient.createService({
+          name: serviceData.name,
           processId: serviceData.id,
           description: serviceData.description,
           package: serviceData.package,
@@ -212,7 +213,10 @@ const Client = function (service, controllerData, serviceData, serviceAbilities,
     }
     return service.tracer.debug(templates.compiled.creatingAbility({
       name: ability.name
-    })).then(() => apiClient.createAbility(ability).then(id => {
+    })).then(() => apiClient.createAbility({
+      ...ability,
+      _service: controllerData.serviceId
+    }).then(id => {
       ability._id = id
       return Promise.resolve(id)
     }))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "domapic-service",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@pm2/agent": {
-      "version": "0.5.20",
-      "resolved": "https://registry.npmjs.org/@pm2/agent/-/agent-0.5.20.tgz",
-      "integrity": "sha512-WKZZ1fVlLjwWmN0qBpmR4Q3N8uV7KX5lq4D97ac1vEGHeO58I4GayabqYw7nxg2G/XFPdNIhLX6OrALEGFvv6Q==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@pm2/agent/-/agent-0.5.21.tgz",
+      "integrity": "sha512-N++DLCr2g53BGFob8ITUvmb41eumk0BfuBcPJLljzU1/sePmjf4GAfRjmnelSk8bixGt9B/6lS+j3f5JTmuFGA==",
       "requires": {
         "async": "^2.6.0",
+        "chalk": "^2.3.2",
         "eventemitter2": "^5.0.1",
         "fclone": "^1.0.11",
         "moment": "^2.21.0",
@@ -31,9 +32,9 @@
       }
     },
     "@pm2/agent-node": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@pm2/agent-node/-/agent-node-1.1.0.tgz",
-      "integrity": "sha512-mgs/WwI2y+4CCn4wdkEwrbIxhRtp4uokKt7q2SvanZwR6MxnrWH9qU2uZGKJg23PGlv48imYG6MZv0zUFfWPoQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@pm2/agent-node/-/agent-node-1.1.3.tgz",
+      "integrity": "sha512-xOQUbqnKkwWIDfzH1PMVwCQxur1gK/asCSvCHnE8u1O1FC/93FAq3m0Xc5ckFApibSwZYDRqUikE8yC/WnCN6A==",
       "requires": {
         "debug": "^3.1.0",
         "eventemitter2": "^5.0.1",
@@ -101,9 +102,9 @@
       }
     },
     "@pm2/js-api": {
-      "version": "0.5.39",
-      "resolved": "https://registry.npmjs.org/@pm2/js-api/-/js-api-0.5.39.tgz",
-      "integrity": "sha512-92GhpPfd/ipN3Z2cebxwURNy2vV6OaPqLMVtKLpExKSs3HN+KebsTEMGoaBoslXI54BnxTY7iVqziIfSrIBUMg==",
+      "version": "0.5.42",
+      "resolved": "https://registry.npmjs.org/@pm2/js-api/-/js-api-0.5.42.tgz",
+      "integrity": "sha512-RxGhIFDjizmQ3rNQ4IOYMltk6CdrccuWq7bzMf7KtFtsbyh/jazmGysIgtkeDUw19Yy9eVMH75YZYCwGSiNJnQ==",
       "requires": {
         "async": "^2.4.1",
         "axios": "^0.16.2",
@@ -322,7 +323,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-includes": {
@@ -916,7 +917,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -1118,9 +1119,9 @@
       }
     },
     "cron": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/cron/-/cron-1.5.1.tgz",
-      "integrity": "sha512-KXadzIvC7hvS7eMWw+L0AK10CBKc596K7DNGi0rOsSnp9QjiSWyiwKv4pBZCMvOZTPgAMotXNttkRwP7ymYlzQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-1.6.0.tgz",
+      "integrity": "sha512-8OkXbeK3qF42ndzkIkCo3zfCDg2TxGjQiCQqVE+ZFFHa4vAcw0PdBc5i/6aJ9FppLncyKZmDuZdJ9/uuXEYZaw==",
       "requires": {
         "moment-timezone": "^0.5.x"
       }
@@ -1160,9 +1161,9 @@
       "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ=="
     },
     "date-fns": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
-      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw=="
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
     },
     "dateformat": {
       "version": "3.0.3",
@@ -1383,9 +1384,9 @@
       }
     },
     "domapic-base": {
-      "version": "1.0.0-beta.18",
-      "resolved": "https://registry.npmjs.org/domapic-base/-/domapic-base-1.0.0-beta.18.tgz",
-      "integrity": "sha512-1YeH1PXQFTCPdViVNT9R7SZs59JuPGS8WMolez6Kn3oPV+06NNfb4GSeAoM2Z8O6689biruRoi2khPhnC1VTwg==",
+      "version": "1.0.0-beta.19",
+      "resolved": "https://registry.npmjs.org/domapic-base/-/domapic-base-1.0.0-beta.19.tgz",
+      "integrity": "sha512-LApi3Kv5MdHW2zn+FqjZ1cwEf12FLMQCeIkIbdyA0brdFwCQk+IrgUFoXA46uDCjDq2kSlfKTnzngZgE0fjj5Q==",
       "requires": {
         "bluebird": "3.5.2",
         "body-parser": "1.18.3",
@@ -1413,9 +1414,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.6.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
-          "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
+          "version": "6.6.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
+          "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -1456,11 +1457,6 @@
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
         },
         "mime-db": {
           "version": "1.37.0",
@@ -1568,6 +1564,14 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -1608,7 +1612,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
@@ -1905,12 +1909,12 @@
       "integrity": "sha1-YZegldX7a1folC9v1+qtY6CclFI="
     },
     "execa": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-      "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "requires": {
         "cross-spawn": "^6.0.0",
-        "get-stream": "^3.0.0",
+        "get-stream": "^4.0.0",
         "is-stream": "^1.1.0",
         "npm-run-path": "^2.0.0",
         "p-finally": "^1.0.0",
@@ -2220,7 +2224,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
@@ -2279,9 +2283,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
+      "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
       "requires": {
         "debug": "=3.1.0"
       },
@@ -2837,7 +2841,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -2848,7 +2852,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -2883,9 +2887,12 @@
       "dev": true
     },
     "get-stream": {
-      "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "requires": {
+        "pump": "^3.0.0"
+      }
     },
     "get-uri": {
       "version": "2.0.2",
@@ -3148,7 +3155,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -3294,9 +3301,9 @@
       }
     },
     "interpret": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
     },
     "invariant": {
       "version": "2.2.4",
@@ -3331,9 +3338,9 @@
       "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
     },
     "is": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
-      "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg=="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -4085,7 +4092,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
@@ -4333,9 +4340,9 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
       "optional": true
     },
     "nanomatch": {
@@ -4565,7 +4572,7 @@
       "dependencies": {
         "eventemitter2": {
           "version": "0.4.14",
-          "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
           "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
         }
       }
@@ -4696,11 +4703,11 @@
       }
     },
     "os-locale": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
-      "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
       "requires": {
-        "execa": "^0.10.0",
+        "execa": "^1.0.0",
         "lcid": "^2.0.0",
         "mem": "^4.0.0"
       }
@@ -4723,7 +4730,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
     },
     "p-limit": {
@@ -4794,7 +4801,7 @@
     },
     "pako": {
       "version": "0.2.9",
-      "resolved": "http://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
     },
     "parse-json": {
@@ -5221,9 +5228,18 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "punycode": {
       "version": "1.4.1",
@@ -5542,7 +5558,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -6043,7 +6059,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
@@ -6551,7 +6567,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -6707,9 +6723,9 @@
           }
         },
         "p-limit": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+          "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
           "requires": {
             "p-try": "^2.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "domapic-service",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-beta.1",
   "description": "Base for Domapic Node.js services",
   "main": "index.js",
   "keywords": [
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "bluebird": "3.5.3",
-    "domapic-base": "1.0.0-beta.18",
+    "domapic-base": "1.0.0-beta.19",
     "is-promise": "2.1.0",
     "lodash": "4.17.11",
     "rand-token": "0.4.0",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=domapic
 sonar.projectKey=domapic-service
-sonar.projectVersion=1.0.0-alpha.5
+sonar.projectVersion=1.0.0-beta.1
 
 sonar.sources=.
 sonar.exclusions=node_modules/**,test/end-to-end/fixtures/**

--- a/test/end-to-end/commands/start-controller-auth-disabled.sh
+++ b/test/end-to-end/commands/start-controller-auth-disabled.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+cd test/end-to-end/fixtures/controller
+rm -rf ../../../../${domapic_path}/.domapic/controller/logs
+npm i
+npm run domapic-controller start controller -- --hostName=${controller_host_name} --path=../../../../${domapic_path} --db=${db_uri} --save --auth=false
+npm run domapic-controller logs controller

--- a/test/end-to-end/commands/start-service-auth-disabled.sh
+++ b/test/end-to-end/commands/start-service-auth-disabled.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+API_KEY=$(node test/end-to-end/commands/get-controller-api-key.js)
+
+echo "CONTROLLER API KEY--------------> ${API_KEY}"
+
+node test/end-to-end/fixtures/${fixture}/server.js --name=${service_name} --hostName=${service_host_name} --port=${service_port} --path=${domapic_path} --controller=http://${controller_host_name}:3000 --auth=false --logLevel=debug --save

--- a/test/end-to-end/fixtures/controller/package.json
+++ b/test/end-to-end/fixtures/controller/package.json
@@ -6,6 +6,6 @@
     "domapic-controller": "node_modules/.bin/domapic-controller"
   },
   "dependencies": {
-    "domapic-controller": "1.0.0-alpha.13"
+    "domapic-controller": "1.0.0-alpha.14"
   }
 }

--- a/test/functional/fixtures/multiple-abilities/server.js
+++ b/test/functional/fixtures/multiple-abilities/server.js
@@ -141,6 +141,24 @@ domapic.createModule({
         }
       }
     },
+    numericDecimalConsole: {
+      description: 'Handle numeric enum console logs',
+      data: {
+        type: 'number',
+        minimum: 10,
+        maximum: 40
+      },
+      event: {
+        description: 'Console has just printed a decimal number'
+      },
+      action: {
+        description: 'Print the received decimal number into console',
+        handler: (data) => {
+          consoleLog(data, 'numericDecimalConsole')
+          return Promise.resolve(data)
+        }
+      }
+    },
     noDataConsole: {
       description: 'Prints hello into console',
       event: {

--- a/test/functional/plugin-specs/config-api.specs.js
+++ b/test/functional/plugin-specs/config-api.specs.js
@@ -27,6 +27,7 @@ test.describe('config api', function () {
           port: parseInt(utils.SERVICE_PORT, 10),
           exampleOption: false,
           authDisabled: [],
+          auth: true,
           hostName: utils.SERVICE_HOST,
           path: path.resolve(__dirname, '..', '..', '..', utils.DOMAPIC_PATH),
           rejectUntrusted: false

--- a/test/functional/specs/ability-number-decimal.specs.js
+++ b/test/functional/specs/ability-number-decimal.specs.js
@@ -1,0 +1,39 @@
+
+const test = require('narval')
+const testUtils = require('narval/utils')
+
+const utils = require('./utils')
+
+test.describe('when using a numeric ability with decimals', function () {
+  this.timeout(10000)
+  let connection
+
+  test.before(() => {
+    return utils.waitOnestimatedStartTime(2000)
+      .then(() => {
+        connection = new utils.Connection()
+        return Promise.resolve()
+      })
+  })
+
+  test.it('should dispatch ability action when a valid number is provided', () => {
+    return connection.request('/abilities/numeric-decimal-console/action', {
+      method: 'POST',
+      body: {
+        data: 20.5
+      }
+    }).then((response) => {
+      return utils.waitOnestimatedStartTime(100)
+        .then(() => {
+          return testUtils.logs.combined('domapic-service')
+            .then((log) => {
+              return Promise.all([
+                test.expect(response.statusCode).to.equal(200),
+                test.expect(log).to.contain(`Console Called: 20.5`),
+                test.expect(log).to.contain(`Error sending "numericDecimalConsole" event: The service is not connected to Controller`)
+              ])
+            })
+        })
+    })
+  })
+})

--- a/test/functional/specs/config-api.specs.js
+++ b/test/functional/specs/config-api.specs.js
@@ -27,6 +27,7 @@ test.describe('config api', function () {
           port: parseInt(utils.SERVICE_PORT, 10),
           initialStatus: true,
           authDisabled: [],
+          auth: true,
           hostName: utils.SERVICE_HOST,
           path: path.resolve(__dirname, '..', '..', '..', utils.DOMAPIC_PATH),
           rejectUntrusted: false,


### PR DESCRIPTION
### BREAKING CHANGES
- From now, connection process not compatible with Domapic Controller versions lower than 1.0.0-alpha.14.

### Changed
- Send service name and ability service on connection process. Now connection works even when authentication is disabled.
- Upgrade domapic-controller version in end-to-end tests.
- Upgrade domapic-base version.